### PR TITLE
Add compliance, readiness, and trust center codex docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ pnpm --filter @apps/ops vectorstore
 
 Le script crée automatiquement le vector store `authorities-francophone` si `OPENAI_VECTOR_STORE_AUTHORITIES_ID` est vide.
 
+### Gouvernance, conformité et Trust Center
+
+Consolidez vos preuves opérationnelles et réglementaires à l'aide des codex et runbooks suivants :
+
+- `docs/governance/cepej_eu_ai_act_codex.md` : synthèse des contrôles CEPEJ et EU AI Act, escalades et artefacts attendus.
+- `docs/operations/operations_readiness_overview.md` : checklist de préparation opérationnelle, activités Day-0/Day-1 et boucle d'amélioration continue.
+- `docs/governance/trust_center_codex.md` : organisation du Trust Center, cadence de publication et obligations de transparence.
+
+Ces documents complètent les runbooks existants (red-team, disaster recovery, FRIA) et servent de référence lors des audits, briefings régulateurs et revues clients.
+
 ### Lancer la campagne d'évaluation
 
 Un CLI dédié exécute les cas d'évaluation stockés dans la table `eval_cases`, appelle l'API `/runs` et journalise les résultats dans `eval_results` :

--- a/docs/governance/cepej_eu_ai_act_codex.md
+++ b/docs/governance/cepej_eu_ai_act_codex.md
@@ -1,0 +1,46 @@
+# CEPEJ & EU AI Act Compliance Handling Codex
+
+This codex summarises how Avocat-AI Francophone operationalises the Council of Europe's CEPEJ ethical charter and the EU AI Act (high-risk) governance requirements. It links automated safeguards implemented in the codebase with recurring human review and evidence capture expectations for regulators, clients, and internal risk teams.
+
+## 1. Governance Objectives
+
+- **Protect fundamental rights and fairness** – The orchestrator enforces structured reasoning, citation validation, and Maghreb binding-language banners before responses leave the agent pipeline. CEPEJ principles on transparency, non-discrimination, and user control are encoded as run-level acceptance gates.
+- **Maintain documented FRIA checkpoints** – Every high-risk workflow must provide a Fundamental Rights Impact Assessment snapshot alongside remediation tickets when violations surface. The FRIA template in `docs/governance/fria_template.md` anchors the minimum evidence set and escalation flow.
+- **Expose continuous monitoring artefacts** – `/metrics/governance`, `/metrics/cepej`, transparency reports, and SLO ledgers must remain exportable to back quarterly regulator briefings, Trust Center updates, and customer diligence.
+
+## 2. Automated Controls in Product & API
+
+| Control Area | Implementation | Evidence Sources |
+| --- | --- | --- |
+| **Run gating** | `apps/api/src/agent.ts` applies CEPEJ policy checks, EU AI Act FRIA detection, France judge-analytics prohibitions, and HITL escalation when violations are detected. | Compliance audit logs, HITL queue entries, `agent_runs` table metadata. |
+| **Compliance service** | `apps/api/src/compliance.ts` normalises CEPEJ charter scenarios (transparency, impartiality, user control) and raises structured violation payloads that populate Go / No-Go criteria. | Compliance violations table, `/runs/:id` response payloads, Go / No-Go checklist exports. |
+| **Metrics & dashboards** | `/metrics/cepej`, `/metrics/governance`, and regulator digests summarise pass rates, outstanding violations, and remediations. SLO snapshots, transparency reports, and CEPEJ exports are persisted for audit. | Supabase views (`cepej_metrics_view`), `transparency_reports`, `slo_snapshots`, `governance_publications`. |
+| **Testing & CI hooks** | `apps/api/test/compliance.test.{ts,js}` and `apps/api/test/agent.test.{ts,js}` validate CEPEJ detection logic, ensuring new changes cannot regress compliance guardrails. | CI pipeline artefacts, evaluation report diffs. |
+
+## 3. Manual Governance Workflow
+
+1. **Daily triage** – Compliance and legal operators review the CEPEJ summary dashboard each morning. Violations trigger the documented mitigation process in `docs/operations/red_team_playbook.md` and assign remediation tickets with owners and deadlines.
+2. **Weekly FRIA review** – The Responsible AI committee downloads FRIA artefacts and CEPEJ exports, confirming mitigation status, residual risk ratings, and user-control affordances. Material changes must be reflected in the Trust Center within 24 hours.
+3. **Monthly transparency publication** – Use `pnpm ops:transparency` to generate regulator-facing reports, attach CEPEJ evidence, and submit to the governance publication ledger. Ensure Maghreb/Rwanda residency commitments, SLO targets, and HITL statistics are included.
+4. **Quarterly audit rehearsal** – Run the full Go / No-Go checklist (`ops/reports/GO_NO_GO_CHECKLIST.md`), rehydrate red-team findings, and capture CEPEJ compliance attestations for board sign-off.
+
+## 4. Incident & Escalation Handling
+
+- **Violation severity**
+  - _Critical_: Fundamental rights impact without mitigation or transparency (e.g., missing citations, non-consented personal data). Immediate HITL shutdown, regulator notification, and Go / No-Go failure until remediation.
+  - _High_: Transparency gaps or automation bias with active mitigation. Requires 24-hour remediation and Trust Center disclosure.
+  - _Medium_: Documentation or monitoring gaps. Resolve within the sprint and document in the monthly transparency report.
+- **Escalation ladder** – Product owner → Compliance lead → Responsible AI committee → Executive sponsor. Regulator dispatches follow the ledger process in `supabase/migrations/20240101004600_regulator_dispatches.sql` and must be published in the Trust Center incidents section.
+- **Post-incident review** – Capture timeline, root cause, CEPEJ principle impacted, FRIA update, corrective actions, and follow-up validations. Archive in the `governance_publications` store with reference to affected runs.
+
+## 5. Evidence Checklist
+
+| Artefact | Frequency | Owner |
+| --- | --- | --- |
+| CEPEJ metrics export (`pnpm ops:transparency --json`) | Weekly | Compliance operations |
+| FRIA updates & residual risk register | Weekly | Responsible AI committee |
+| Go / No-Go CEPEJ criterion status | Per release | Release manager |
+| HITL queue and remediation ticket logs | Daily | Support operations |
+| Trust Center compliance bulletin | Within 24h of change | Communications lead |
+
+Adhering to this codex ensures Avocat-AI Francophone aligns with CEPEJ ethical imperatives and EU AI Act obligations while delivering auditable, regulator-ready evidence at all times.

--- a/docs/governance/trust_center_codex.md
+++ b/docs/governance/trust_center_codex.md
@@ -1,0 +1,52 @@
+# Trust Center Codex
+
+The Trust Center codex prescribes how Avocat-AI Francophone communicates operational, compliance, and performance evidence to customers, regulators, and the public. It aligns with CEPEJ, EU AI Act, and Council of Europe transparency expectations while preserving client confidentiality.
+
+## 1. Purpose & Scope
+
+- Provide a single source of truth for policies, certifications, incident history, SLO performance, and compliance attestations.
+- Enable rapid updates (within 24 hours) when CEPEJ/EU AI Act status changes, incidents occur, or new jurisdictions are launched.
+- Support procurement, due diligence, and regulator briefings with exportable artefacts.
+
+## 2. Core Sections & Required Content
+
+| Section | Content | Update Cadence |
+| --- | --- | --- |
+| **Overview** | Mission statement, leadership contacts, responsible AI commitments, summary of CEPEJ/EU AI Act alignment. | Quarterly or upon material change. |
+| **Compliance & Governance** | CEPEJ charter mapping (summary and PDF export), EU AI Act FRIA template, Council of Europe alignment, residency matrix, conflict of interest policy. | Update alongside any policy change. |
+| **Operational Readiness** | SLO dashboard snapshot, incident response SLAs, support hours, Go / No-Go checklist status, operations readiness overview link. | Monthly or after drills. |
+| **Security & Privacy** | Data handling statement, encryption posture, access control overview, regulator dispatch log summary, DPIA artefacts. | Within 24h of policy change. |
+| **Incidents & Notifications** | Past 12 months incident summaries, remediation status, regulator notifications (linked to `regulator_dispatches`). | Within 24h of new incident. |
+| **Performance & Evaluations** | Latest red-team and evaluation summaries, LegalBench/LexGLUE benchmarks, performance snapshot metrics, CEPEJ pass rate chart. | Monthly or after major release. |
+
+## 3. Publication Workflow
+
+1. Draft updates in Markdown (mirroring `apps/web/public/governance` content) and secure review from Compliance, Security, and Communications leads.
+2. Generate supporting artefacts:
+   - `pnpm ops:transparency` for CEPEJ metrics and FRIA evidence.
+   - `pnpm ops:perf-snapshot` for latency and accuracy telemetry.
+   - `pnpm ops:red-team` / `pnpm ops:evaluate` for guardrail and accuracy updates.
+3. Publish updates to the Trust Center web pages, ensuring bilingual (FR/EN) parity and accessibility requirements (WCAG 2.2 AA) are met.
+4. Log the publication in `governance_publications` with timestamp, owner, and summary of changes.
+
+## 4. Change Control & Versioning
+
+- Maintain Git history for all Trust Center Markdown updates with descriptive commit messages referencing incident IDs or policy tickets.
+- Store exported artefacts (PDF, JSON) in versioned Supabase buckets with retention aligned to regulator expectations (≥ 5 years).
+- For emergency updates, use the expedited approval path: Communications lead + Compliance lead + Executive sponsor.
+
+## 5. Alignment with Other Artefacts
+
+- **Operations Readiness Overview** – Link and surface current operational posture and evidence repositories.
+- **CEPEJ & EU AI Act Compliance Codex** – Reference governance obligations and highlight user-control affordances.
+- **Disaster Recovery Runbook & Incident Response Plan** – Provide direct download links and summarise test frequency/results.
+- **Pricing & Onboarding Collateral** – Ensure sales collateral references Trust Center resources for procurement enablement.
+
+## 6. Metrics for Success
+
+- Trust Center updates published within SLA 100% of the time.
+- CEPEJ pass rate ≥ 95% with remediation status visible on the Trust Center dashboard.
+- Time-to-disclosure for incidents ≤ 24 hours.
+- Positive feedback from customer due diligence (tracked via onboarding surveys) referencing Trust Center clarity.
+
+Adhering to this codex guarantees consistent, regulator-grade transparency and reinforces customer confidence in Avocat-AI Francophone.

--- a/docs/operations/operations_readiness_overview.md
+++ b/docs/operations/operations_readiness_overview.md
@@ -1,0 +1,50 @@
+# Operations Readiness Overview
+
+This overview establishes the operational readiness baseline for Avocat-AI Francophone. It consolidates pre-launch obligations, day-0/1 runbooks, and continuous assurance workflows that operations, support, and engineering teams must satisfy before shipping to regulated clients.
+
+## 1. Pre-Launch Checklist
+
+1. **Infrastructure baselines**
+   - Apply all Supabase migrations (`pnpm db:migrate`) and confirm storage buckets (`authorities`, `uploads`, `snapshots`) plus Postgres extensions (`pgvector`, `pg_trgm`).
+   - Run `pnpm ops:check` to validate environment prerequisites, vector store reachability, and allowlist synchronisation.
+   - Ensure incident and regulator dispatch ledgers are migrated (`supabase/migrations/20240101004500_transparency_reports.sql`, `20240101004600_regulator_dispatches.sql`).
+2. **Security & access controls**
+   - Configure SSO/SCIM, enforce MFA, and validate RBAC/ABAC policies in Supabase and the web console.
+   - Seed residency and lawful basis matrices for Maghreb, Rwanda, EU, and OHADA jurisdictions.
+   - Verify confidential mode policies and audit log retention windows in `apps/api/src/server.ts` governance endpoints.
+3. **Compliance scaffolding**
+   - Publish CEPEJ charter mapping, EU AI Act FRIA template, and Council of Europe alignment note in the Trust Center.
+   - Run red-team (`pnpm ops:red-team`) and evaluation campaigns (`pnpm ops:evaluate`) capturing evidence in Supabase.
+   - Execute the Go / No-Go checklist and secure sign-off from the Responsible AI committee.
+
+## 2. Day-0 Launch Activities
+
+- **Cutover rehearsal** – Perform a dry run of ingestion pipelines, agent orchestrator, and HITL queue in staging with monitoring dashboards enabled.
+- **Support onboarding** – Train support staff on CEPEJ/EU AI Act escalation ladder, ticket triage, and Trust Center update flows.
+- **Communications readiness** – Draft initial Trust Center bulletin, status page incident templates, and regulator contact scripts.
+- **Monitoring verification** – Confirm `/metrics/governance`, `/metrics/cepej`, `/metrics/slo`, and `/reports/dispatches` endpoints return data aligned with Supabase records.
+
+## 3. Day-1 Steady State
+
+| Function | Daily | Weekly | Monthly |
+| --- | --- | --- | --- |
+| Operations | Review SLO dashboard, CEPEJ alerts, and HITL backlog. Ensure remediation tickets tracked in ops system. | Publish CEPEJ metrics export to compliance. | Refresh performance snapshot (`pnpm ops:perf-snapshot`) and archive in Trust Center. |
+| Support | Validate incident queue, ensure SLA coverage, and update Trust Center if incidents occur. | Run spot checks on residency banners and Maghreb/Rwanda localisation. | Participate in post-incident drills and update playbooks. |
+| Engineering | Inspect error budgets, retrier logs, and vector store health. | Rotate credentials, review red-team backlog, schedule dependency updates. | Execute disaster recovery drill and publish results. |
+
+## 4. Readiness Evidence Repository
+
+All readiness evidence must be centralised to support audits and regulator inquiries:
+
+- **Supabase** – `transparency_reports`, `slo_snapshots`, `performance_snapshots`, `red_team_findings`, `eval_results`, `governance_publications`, `regulator_dispatches`.
+- **Docs** – Disaster recovery runbook, red-team playbook, CEPEJ charter mapping, FRIA template, data residency matrix, pricing collateral.
+- **Dashboards** – Operator console compliance overview, trust-tiered corpus health, residency coverage, HITL queue metrics.
+
+## 5. Continuous Improvement Loop
+
+1. Capture feedback from operators and clients weekly, linking issues to remediation tickets and tracking closure time.
+2. Feed lessons learned into the red-team backlog, evaluation cases, and agent learning pipelines (`apps/edge/process-learning`).
+3. Update Trust Center resources and readiness documentation whenever controls change or new jurisdictions go live.
+4. Schedule quarterly readiness retrospectives with Compliance, Engineering, Support, and Leadership to review incident trends, CEPEJ/EU AI Act metrics, and SLO performance.
+
+Maintaining this readiness posture ensures Avocat-AI Francophone can evidence operational excellence, compliance maturity, and regulator-grade resilience at any time.


### PR DESCRIPTION
## Summary
- document CEPEJ and EU AI Act compliance handling in a dedicated codex
- capture the operations readiness overview for pre-launch and steady-state duties
- codify Trust Center publication workflows and reference the new materials from the README

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e58569105c8325bd533a29a42a6106